### PR TITLE
Fix use new table names

### DIFF
--- a/app/jobs/sync_linkage_job.rb
+++ b/app/jobs/sync_linkage_job.rb
@@ -87,8 +87,8 @@ class SyncLinkageJob < ApplicationJob
       Rails.logger.info "[#{linkage.id}] Setting Linkage Status to 'Complete'"
       linkage.update(sync_status: :complete, last_sync: Time.current)
       maybe_client.close
-    rescue Net::ReadTimeout => e
-      Rails.logger.error "[#{linkage.id}] Failed to retrieve data from SimpleFIN: #{e.message}"
+    rescue Net::ReadTimeout, ActiveRecord::StatementInvalid, NoMethodError => e
+      Rails.logger.error "[#{linkage.id}] An error occurred: #{e.message}"
       Rails.logger.info "[#{linkage.id}] Setting Linkage Status to 'Error'"
       linkage.update(sync_status: :error)
       maybe_client.close

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,7 +30,7 @@ This command will do the following:
 1. Fetch the sample docker compose file from the public Github repository
 2. Creates a file in your current directory called `docker-compose.yml` with the contents of the example file
 
-At this point, the only file in your current working directory should be `compose.yml`.
+At this point, the only file in your current working directory should be `docker-compose.yml`.
 
 ### Step 3 : Configure your environment
 


### PR DESCRIPTION
Fixes #9 

...by accounting for the environment's `schema_migrations.version`, specifying the appropriate table names and `entryable_type` keys